### PR TITLE
Backfill past-event CSV + add insert workflow

### DIFF
--- a/.github/workflows/insert-backfilled-events.yml
+++ b/.github/workflows/insert-backfilled-events.yml
@@ -1,0 +1,113 @@
+name: Insert Backfilled Past Events
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: 'Big Scrape run ID to pull events_scraped.csv + apify_raw_results.json from'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (rolls back every insert; reports counts only)'
+        required: true
+        type: boolean
+        default: true
+      limit:
+        description: 'Max candidate rows to process (0 = all)'
+        required: true
+        type: string
+        default: '0'
+
+jobs:
+  insert_backfilled:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    env:
+      PRODUCTION: '1'
+      DJANGO_SETTINGS_MODULE: 'config.settings.development'
+      SECRET_KEY: ${{ secrets.SECRET_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      DATABASE_URL: ${{ secrets.SUPABASE_DB_URL }}
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+      POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+      POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_S3_BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL }}
+      EMAIL_ENCRYPTION_KEY: ${{ secrets.EMAIL_ENCRYPTION_KEY }}
+      EMAIL_HASH_KEY: ${{ secrets.EMAIL_HASH_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install --prefer-binary -r requirements.txt
+
+      - name: Download big-scrape artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCE_RUN_ID: ${{ inputs.source_run_id }}
+        run: |
+          mkdir -p artifact
+          gh run download "$SOURCE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir artifact
+          echo "Downloaded files:"
+          find artifact -type f | sort
+
+          # Locate the CSV and JSON regardless of subdir name
+          CSV_PATH=$(find artifact -name 'events_scraped.csv' | head -1)
+          JSON_PATH=$(find artifact -name 'apify_raw_results.json' | head -1)
+          if [ -z "$CSV_PATH" ] || [ -z "$JSON_PATH" ]; then
+            echo "Missing CSV or apify JSON in artifact" >&2
+            exit 1
+          fi
+          echo "CSV_PATH=$CSV_PATH"   >> "$GITHUB_ENV"
+          echo "JSON_PATH=$JSON_PATH" >> "$GITHUB_ENV"
+
+      - name: Backfill CSV
+        working-directory: backend
+        run: |
+          python scripts/backfill_past_event_csv.py \
+            --csv   "../$CSV_PATH" \
+            --apify "../$JSON_PATH" \
+            --out   "../artifact/events_scraped.backfilled.csv"
+
+      - name: Insert backfilled past events
+        working-directory: backend
+        run: |
+          DRY_FLAG=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then DRY_FLAG="--dry-run"; fi
+
+          LIMIT_FLAG=""
+          if [ "${{ inputs.limit }}" != "0" ]; then LIMIT_FLAG="--limit ${{ inputs.limit }}"; fi
+
+          python -u scripts/insert_backfilled_past_events.py \
+            --csv "../artifact/events_scraped.backfilled.csv" \
+            $DRY_FLAG $LIMIT_FLAG \
+            2>&1 | tee insert.log
+
+      - name: Upload backfilled CSV + log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: insert-backfilled-events-${{ github.run_number }}
+          path: |
+            artifact/events_scraped.backfilled.csv
+            backend/insert.log
+          if-no-files-found: 'ignore'

--- a/backend/scraping/event_processor.py
+++ b/backend/scraping/event_processor.py
@@ -269,6 +269,14 @@ class EventProcessor:
                         all_s3_urls[0] if all_s3_urls else ""
                     )
 
+                # Set identifying metadata before any CSV write so every row has handle/source/etc.
+                event_data["ig_handle"] = ig_handle
+                event_data["source_url"] = source_url
+                event_data["school"] = self.school
+                event_data["posted_at"] = post_dt
+                event_data["likes_count"] = post.get("likesCount") or post.get("likeCount") or 0
+                event_data["comments_count"] = post.get("commentsCount") or post.get("commentCount") or 0
+
                 # Check for past date
                 occurrences = event_data.get("occurrences", [])
                 if occurrences:
@@ -283,14 +291,7 @@ class EventProcessor:
                         )
                         continue
 
-                # Add metadata to event_data
-                event_data["ig_handle"] = ig_handle
-                event_data["source_url"] = source_url
-                event_data["school"] = self.school
                 event_data["club_type"] = await self._get_club_type(ig_handle)
-                event_data["likes_count"] = post.get("likesCount") or post.get("likeCount") or 0
-                event_data["comments_count"] = post.get("commentsCount") or post.get("commentCount") or 0
-                event_data["posted_at"] = post_dt
 
                 if self.dry_run:
                     append_event_to_csv(event_data, added_to_db="dry_run")

--- a/backend/scripts/backfill_past_event_csv.py
+++ b/backend/scripts/backfill_past_event_csv.py
@@ -1,0 +1,144 @@
+"""
+Flatten multi-line CSV cells and backfill missing context fields on
+event_past_date rows by matching their AI-extracted description/title against
+the original Apify post captions.
+
+Inputs:
+  --csv      Path to events_scraped.csv (raw, from big_scrape artifact)
+  --apify    Path to apify_raw_results.json (same artifact)
+  --out      Output path for the corrected CSV
+
+Backfilled fields (only on rows where added_to_db == "event_past_date" and
+ig_handle is empty): ig_handle, source_url, posted_at, likes_count, comments_count.
+
+The flatten step also collapses whitespace runs in the description and
+location fields so each row is exactly one line of CSV.
+"""
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+
+csv.field_size_limit(sys.maxsize)
+
+
+QUOTE_MAP = str.maketrans({"‘": "'", "’": "'", "“": '"', "”": '"', "–": "-", "—": "-"})
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True, type=Path)
+    p.add_argument("--apify", required=True, type=Path)
+    p.add_argument("--out", required=True, type=Path)
+    return p.parse_args()
+
+
+def norm(s: str) -> str:
+    if not s:
+        return ""
+    return re.sub(r"\s+", " ", s.lower().translate(QUOTE_MAP)).strip()
+
+
+def flatten(s: str) -> str:
+    if not s:
+        return s
+    return re.sub(r"\s+", " ", str(s)).strip()
+
+
+def fmt_ts(iso: str) -> str:
+    if not iso:
+        return ""
+    s = iso.replace("T", " ").rstrip("Z")
+    s = re.sub(r"\.\d+$", "", s)
+    return s + "+00:00"
+
+
+def build_post_index(apify_path: Path):
+    with apify_path.open() as f:
+        posts = json.load(f)
+    seen = {}
+    for p in posts:
+        cap = p.get("caption") or ""
+        url = p.get("url") or ""
+        handle = p.get("ownerUsername") or ""
+        if cap and url and handle and url not in seen:
+            seen[url] = {
+                "caption_n": norm(cap),
+                "url": url,
+                "handle": handle,
+                "timestamp": p.get("timestamp") or "",
+                "likes": p.get("likesCount") or p.get("likeCount") or 0,
+                "comments": p.get("commentsCount") or p.get("commentCount") or 0,
+            }
+    return list(seen.values())
+
+
+def make_finder(posts_idx):
+    def find_post(desc, title):
+        desc_n = norm(desc)
+        title_n = norm(title)
+        for L in (200, 120, 80, 50, 30, 20):
+            if len(desc_n) >= L:
+                needle = desc_n[:L]
+                ms = [p for p in posts_idx if needle in p["caption_n"]]
+                if len(ms) == 1:
+                    return ms[0]
+        if title_n and len(title_n) >= 8:
+            ms = [p for p in posts_idx if title_n in p["caption_n"]]
+            if len(ms) == 1:
+                return ms[0]
+        return None
+    return find_post
+
+
+FLATTEN_FIELDS = {"description", "location"}
+
+
+def main():
+    args = parse_args()
+
+    posts_idx = build_post_index(args.apify)
+    print(f"Indexed {len(posts_idx)} unique apify posts")
+
+    finder = make_finder(posts_idx)
+    backfilled = unmatched = passthrough = 0
+
+    with args.csv.open("r", encoding="utf-8", newline="") as fin, \
+         args.out.open("w", encoding="utf-8", newline="") as fout:
+        reader = csv.DictReader(fin)
+        fields = reader.fieldnames
+        writer = csv.DictWriter(fout, fieldnames=fields, lineterminator="\n")
+        writer.writeheader()
+
+        for row in reader:
+            for k in FLATTEN_FIELDS:
+                if k in row and row[k]:
+                    row[k] = flatten(row[k])
+
+            if row.get("added_to_db") == "event_past_date" and not row.get("ig_handle"):
+                m = finder(row.get("description"), row.get("title"))
+                if m:
+                    row["ig_handle"] = m["handle"]
+                    row["source_url"] = m["url"]
+                    row["posted_at"] = fmt_ts(m["timestamp"])
+                    row["likes_count"] = m["likes"]
+                    row["comments_count"] = m["comments"]
+                    backfilled += 1
+                else:
+                    unmatched += 1
+            else:
+                passthrough += 1
+
+            writer.writerow(row)
+
+    print(f"Backfilled past_date rows: {backfilled}")
+    print(f"Unmatched past_date rows : {unmatched}")
+    print(f"Passthrough rows         : {passthrough}")
+    print(f"Wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/insert_backfilled_past_events.py
+++ b/backend/scripts/insert_backfilled_past_events.py
@@ -1,0 +1,181 @@
+"""
+Insert backfilled past-date events from a CSV into the DB.
+
+Reads a `events_scraped.csv` produced by the big scrape, picks rows where
+`added_to_db == "event_past_date"` AND `ig_handle` is populated (backfilled),
+and runs them through the standard insert_event_to_db() pipeline so we get
+the same dedup logic the scraper uses.
+
+Usage:
+    python scripts/insert_backfilled_past_events.py --csv PATH [--dry-run]
+
+In --dry-run mode every insert is rolled back, so nothing commits to the DB
+but you get accurate counts for what *would* happen.
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.development")
+django.setup()
+
+from django.db import transaction
+from django.db.transaction import set_rollback
+
+from utils.scraping_utils import insert_event_to_db
+
+csv.field_size_limit(sys.maxsize)
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--csv", required=True, type=Path)
+    p.add_argument("--dry-run", action="store_true",
+                   help="Roll back every insert. Counts are still accurate.")
+    p.add_argument("--limit", type=int, default=0,
+                   help="Process only the first N candidate rows (0 = all).")
+    return p.parse_args()
+
+
+def parse_posted_at(s: str):
+    if not s:
+        return None
+    s = s.strip()
+    for fmt in ("%Y-%m-%d %H:%M:%S%z", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return datetime.strptime(s.replace("Z", "+0000") if fmt.endswith("Z") else s, fmt)
+        except ValueError:
+            continue
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def row_to_event_data(row: dict) -> dict:
+    def jload(s, default):
+        if not s:
+            return default
+        try:
+            return json.loads(s)
+        except json.JSONDecodeError:
+            return default
+
+    def maybe_float(s):
+        if s is None or s == "":
+            return None
+        try:
+            return float(s)
+        except ValueError:
+            return None
+
+    def maybe_int(s, default=0):
+        if s is None or s == "":
+            return default
+        try:
+            return int(s)
+        except ValueError:
+            return default
+
+    return {
+        "ig_handle": row.get("ig_handle") or None,
+        "title": row.get("title") or "",
+        "source_url": row.get("source_url") or None,
+        "location": row.get("location") or None,
+        "food": row.get("food") or None,
+        "price": row.get("price") or None,
+        "registration": row.get("registration", "").lower() == "true",
+        "description": row.get("description") or "",
+        "latitude": maybe_float(row.get("latitude")),
+        "longitude": maybe_float(row.get("longitude")),
+        "school": row.get("school") or "",
+        "source_image_url": row.get("source_image_url") or "",
+        "club_type": row.get("club_type") or None,
+        "categories": jload(row.get("categories"), []),
+        "occurrences": jload(row.get("occurrences"), []),
+        "likes_count": maybe_int(row.get("likes_count"), 0),
+        "comments_count": maybe_int(row.get("comments_count"), 0),
+        "posted_at": parse_posted_at(row.get("posted_at") or ""),
+    }
+
+
+def main():
+    args = parse_args()
+
+    if not args.csv.is_file():
+        print(f"CSV not found: {args.csv}", file=sys.stderr)
+        sys.exit(1)
+
+    candidates = []
+    with args.csv.open("r", encoding="utf-8", newline="") as f:
+        for row in csv.DictReader(f):
+            if row.get("added_to_db") == "event_past_date" and row.get("ig_handle"):
+                candidates.append(row)
+
+    if args.limit:
+        candidates = candidates[: args.limit]
+
+    print(f"Candidate rows to process: {len(candidates)}")
+    print(f"Mode: {'DRY-RUN (rollback)' if args.dry_run else 'COMMIT'}")
+    print(f"Target DB host: {os.getenv('POSTGRES_HOST') or '(from DATABASE_URL)'}")
+    print()
+
+    outcomes = Counter()
+    sample_per_outcome = {}
+
+    for i, row in enumerate(candidates, start=1):
+        event_data = row_to_event_data(row)
+        try:
+            with transaction.atomic():
+                result = insert_event_to_db(event_data)
+                if args.dry_run:
+                    set_rollback(True)
+        except Exception as e:
+            result = f"exception: {type(e).__name__}"
+            outcomes[result] += 1
+            sample_per_outcome.setdefault(
+                result,
+                {"title": event_data.get("title"), "ig_handle": event_data.get("ig_handle"), "err": str(e)[:200]},
+            )
+            continue
+
+        # Normalize result label
+        if result is True:
+            label = "would_insert" if args.dry_run else "inserted"
+        elif result is False:
+            label = "error"
+        else:
+            label = str(result)
+
+        outcomes[label] += 1
+        if label not in sample_per_outcome:
+            sample_per_outcome[label] = {
+                "title": event_data.get("title"),
+                "ig_handle": event_data.get("ig_handle"),
+                "source_url": event_data.get("source_url"),
+            }
+
+        if i % 200 == 0:
+            print(f"  ...processed {i}/{len(candidates)}: {dict(outcomes)}")
+
+    print()
+    print("=== SUMMARY ===")
+    for k, v in outcomes.most_common():
+        print(f"  {k:<22} {v}")
+    print()
+    print("=== SAMPLE PER OUTCOME ===")
+    for k, sample in sample_per_outcome.items():
+        print(f"  {k}: {sample}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/utils/scraping_utils.py
+++ b/backend/utils/scraping_utils.py
@@ -407,10 +407,17 @@ class EventDuplicateDetector:
         return None
 
 
+def _flatten_whitespace(value):
+    """Collapse newlines and runs of whitespace to single spaces so each CSV row stays on one line."""
+    if not value:
+        return value
+    return re.sub(r"\s+", " ", str(value)).strip()
+
+
 def append_event_to_csv(event_data, added_to_db="success"):
     """
     Append event data to CSV file for logging/debugging.
-    
+
     Args:
         event_data: Dictionary containing all event data and metadata
         added_to_db: Status of the database operation (success, error, duplicate_post, etc.)
@@ -434,11 +441,11 @@ def append_event_to_csv(event_data, added_to_db="success"):
     dtend_utc = primary_occurrence.get("dtend_utc")
     duration = primary_occurrence.get("duration")
     tz = primary_occurrence.get("tz")
-    location = event_data.get("location", "")
+    location = _flatten_whitespace(event_data.get("location", ""))
     food = event_data.get("food", "")
     price = event_data.get("price", "")
     registration = bool(event_data.get("registration", False))
-    description = event_data.get("description", "")
+    description = _flatten_whitespace(event_data.get("description", ""))
     latitude = event_data.get("latitude", None)
     longitude = event_data.get("longitude", None)
     school = event_data.get("school", "")


### PR DESCRIPTION
## Summary
- Fix CSV `ig_handle`/`source_url`/`posted_at`/`likes_count`/`comments_count` gap on `event_past_date` rows in `events_scraped.csv` (metadata block ran *after* the past-date `continue`)
- Flatten newlines in `description`/`location` so each CSV row stays on one line
- Add `backfill_past_event_csv.py` to rebuild missing context by matching AI descriptions to apify captions (~94% match rate against the 2026-04-27 UPenn run)
- Add `insert_backfilled_past_events.py` to insert past events using the same `insert_event_to_db` dedup path
- Add `insert-backfilled-events.yml` workflow that pulls a big-scrape artifact, runs the backfill, and inserts (dry-run capable)

Once merged, dispatch via `gh workflow run insert-backfilled-events.yml -f source_run_id=25016164019 -f dry_run=true`.

## Test plan
- [x] backfill script reproduces local match counts (2042 backfilled / 137 unmatched / 81 passthrough) against the 25016164019 artifact
- [ ] CI dry-run: confirm DB connectivity + report would-insert/duplicate/error counts
- [ ] CI commit run: insert past events into prod DB