### PR TITLE
Add school dropdown on events page

### DIFF
--- a/backend/apps/events/views.py
+++ b/backend/apps/events/views.py
@@ -76,9 +76,11 @@ def get_events(request):
         limit = 20
         all_events = request.GET.get("all", "").lower() == "true"
 
-        # Start with Events queryset
+        # Start with Events queryset; default to UW when no school is given
+        # so existing UW callers stay unaffected.
+        school_param = request.GET.get("school") or "University of Waterloo"
         events_queryset = Events.objects.filter(
-            status="CONFIRMED", school="University of Waterloo"
+            status="CONFIRMED", school=school_param
         )
 
         # Upcoming events filter: show all live and future events by default

--- a/frontend/src/features/events/components/SchoolSelect.tsx
+++ b/frontend/src/features/events/components/SchoolSelect.tsx
@@ -1,0 +1,37 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/components/ui/select";
+import { SCHOOLS } from "@/features/events/constants/events";
+
+interface SchoolSelectProps {
+  value: string;
+  onChange: (next: string) => void;
+  className?: string;
+}
+
+const SchoolSelect: React.FC<SchoolSelectProps> = ({
+  value,
+  onChange,
+  className,
+}) => {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className={className} aria-label="Select school">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {SCHOOLS.map((school) => (
+          <SelectItem key={school.value} value={school.value}>
+            {school.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default SchoolSelect;

--- a/frontend/src/features/events/constants/events.ts
+++ b/frontend/src/features/events/constants/events.ts
@@ -1,1 +1,11 @@
 export const EVENTS_PER_PAGE = 24;
+
+export const SCHOOLS = [
+  { value: "University of Waterloo", label: "Waterloo" },
+  { value: "University of Pennsylvania", label: "UPenn" },
+  { value: "New York University", label: "NYU" },
+  { value: "Columbia University", label: "Columbia" },
+  { value: "Massachusetts Institute of Technology", label: "MIT" },
+] as const;
+
+export const DEFAULT_SCHOOL = SCHOOLS[0].value;

--- a/frontend/src/features/events/hooks/useEventInterest.ts
+++ b/frontend/src/features/events/hooks/useEventInterest.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient, InfiniteData } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient, type InfiniteData } from "@tanstack/react-query";
 import { useAuth } from "@clerk/clerk-react";
 import { useApi } from "@/shared/hooks/useApi";
 import type { EventsResponse } from "@/shared/api/EventsAPIClient";
@@ -8,7 +8,7 @@ import type { Event } from "@/features/events/types/events";
  * Hook to get all event IDs the current user is interested in
  */
 export function useMyInterestedEvents() {
-  const { isSignedIn } = useAuth();
+  const { isLoaded, isSignedIn } = useAuth();
   const { eventsAPIClient } = useApi();
 
   return useQuery({
@@ -17,7 +17,9 @@ export function useMyInterestedEvents() {
       const response = await eventsAPIClient.getMyInterestedEventIds();
       return new Set(response.event_ids); // Convert to Set for O(1) lookup
     },
-    enabled: isSignedIn,
+    // Wait for Clerk to finish loading. While `isSignedIn` is undefined,
+    // TanStack treats `enabled: undefined` as true and fires a 401.
+    enabled: isLoaded && isSignedIn === true,
     staleTime: 1000 * 60 * 5, // Cache for 5 minutes
     meta: {
       skipErrorToast: true,

--- a/frontend/src/features/events/hooks/useEvents.ts
+++ b/frontend/src/features/events/hooks/useEvents.ts
@@ -6,8 +6,9 @@ import { useDocumentTitle } from "@/shared/hooks/useDocumentTitle";
 import { useApi } from "@/shared/hooks/useApi";
 import { getTodayString } from "@/shared/lib/dateUtils";
 import { useMyInterestedEvents } from "./useEventInterest";
-import { EventsResponse, type EventsQueryParams } from "@/shared/api/EventsAPIClient";
-import { Event } from "@/features/events";
+import { DEFAULT_SCHOOL } from "@/features/events/constants/events";
+import type { EventsResponse, EventsQueryParams } from "@/shared/api/EventsAPIClient";
+import type { Event } from "@/features/events";
 
 export function useEvents() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -20,6 +21,7 @@ export function useEvents() {
   const addedAt = searchParams.get("added_at") || "";
   const showInterested = searchParams.get("interested") === "true";
   const view = searchParams.get("view") || "grid";
+  const school = searchParams.get("school") || DEFAULT_SCHOOL;
 
   const { data: interestedEventIds } = useMyInterestedEvents();
 
@@ -44,11 +46,12 @@ export function useEvents() {
       dtstart_utc,
       addedAt,
       view,
+      school,
       showInterested ? "interested" : "",
     ],
     queryFn: async ({ pageParam }: { pageParam: string | undefined }) => {
       const queryParams: EventsQueryParams = {
-        school: "University of Waterloo",
+        school,
       };
 
       if (pageParam) {
@@ -157,6 +160,18 @@ export function useEvents() {
     });
   };
 
+  const handleSchoolChange = (nextSchool: string) => {
+    setSearchParams((prev) => {
+      const nextParams = new URLSearchParams(prev);
+      if (nextSchool === DEFAULT_SCHOOL) {
+        nextParams.delete("school");
+      } else {
+        nextParams.set("school", nextSchool);
+      }
+      return nextParams;
+    });
+  };
+
   const handleToggleStartDate = () => {
     setSearchParams((prev) => {
       const nextParams = new URLSearchParams(prev);
@@ -252,7 +267,9 @@ export function useEvents() {
     dtstart_utc,
     addedAt,
     showInterested,
+    school,
     handleViewChange,
+    handleSchoolChange,
     handleToggleStartDate,
     handleToggleNewEvents,
     handleToggleInterested,

--- a/frontend/src/features/events/hooks/useUserSubmissions.ts
+++ b/frontend/src/features/events/hooks/useUserSubmissions.ts
@@ -4,7 +4,7 @@ import { useAuth } from '@clerk/clerk-react';
 import type { EventSubmission } from '@/features/events/types/submission';
 
 export const useUserSubmissions = () => {
-  const { isSignedIn, userId } = useAuth();
+  const { isLoaded, isSignedIn, userId } = useAuth();
   const { eventsAPIClient } = useApi();
   const queryClient = useQueryClient();
 
@@ -12,7 +12,7 @@ export const useUserSubmissions = () => {
   const submissionsQuery = useQuery<EventSubmission[]>({
     queryKey: ['user-submissions', userId],
     queryFn: () => eventsAPIClient.getUserSubmissions(),
-    enabled: isSignedIn && !!userId,
+    enabled: isLoaded && isSignedIn === true && !!userId,
     staleTime: 30 * 1000,  
     gcTime: 5 * 60 * 1000,  
   });

--- a/frontend/src/features/events/index.ts
+++ b/frontend/src/features/events/index.ts
@@ -1,8 +1,9 @@
 export { default as EventsGrid } from './components/EventsGrid';
 export { default as EventsCalendar } from './components/EventsCalendar';
 export { default as EventLegend } from './components/EventLegend';
-export { default as QuickFilters } from './components/QuickFilters'; 
+export { default as QuickFilters } from './components/QuickFilters';
 export { default as EventsContent } from './components/EventsContent';
+export { default as SchoolSelect } from './components/SchoolSelect';
 
 // Hooks
 export { useEvents } from './hooks/useEvents';

--- a/frontend/src/features/events/pages/EventsPage.tsx
+++ b/frontend/src/features/events/pages/EventsPage.tsx
@@ -143,11 +143,9 @@ function EventsPage() {
               suffix={` ${getEventTypeText()} events`}
             />
           </h1>
-          <p className="text-gray-600 dark:text-gray-400 text-sm sm:text-base">
+          <div className="text-gray-600 dark:text-gray-400 text-sm sm:text-base">
             {isLoadingLastUpdate ? (
-              <span className="inline-flex items-center gap-2">
-                <Skeleton className="h-5 w-48 inline-block" />
-              </span>
+              <Skeleton className="h-5 w-48" />
             ) : latestUpdateData?.latestEventTitle && latestUpdateData?.lastUpdated ? (
               <>
                 <Link
@@ -162,7 +160,7 @@ function EventsPage() {
             ) : (
               "No recent updates"
             )}
-          </p>
+          </div>
         </div>
 
         <div className="flex flex-col sm:gap-4 gap-3.5">

--- a/frontend/src/features/events/pages/EventsPage.tsx
+++ b/frontend/src/features/events/pages/EventsPage.tsx
@@ -6,6 +6,7 @@ import {
   useEventSelection,
   EventsContent,
   QuickFilters,
+  SchoolSelect,
 } from "@/features/events";
 import {
   getTodayString,
@@ -62,6 +63,8 @@ function EventsPage() {
     showInterested,
     searchTerm,
     categories,
+    school,
+    handleSchoolChange,
     handleToggleNewEvents,
     handleToggleInterested,
     handleToggleAllEvents,
@@ -165,6 +168,7 @@ function EventsPage() {
         <div className="flex flex-col sm:gap-4 gap-3.5">
           <div className="flex items-center sm:gap-4 gap-2">
             <SearchInput placeholder={placeholder} className="flex-1" />
+            <SchoolSelect value={school} onChange={handleSchoolChange} />
             <Tabs
               value={view}
               onValueChange={(value) =>


### PR DESCRIPTION
## Summary
- Replace hardcoded `school: "University of Waterloo"` in `useEvents` with a URL-driven `school` param (defaults to UW)
- New `SchoolSelect` dropdown next to the search bar / view tabs (Waterloo / UPenn / NYU / Columbia / MIT — same set as the big-scrape workflow inputs)
- `school` added to the React Query key so the cache busts cleanly on switch

## Test plan
- [ ] `npm run dev` — switch schools in dropdown, confirm events refetch and URL updates with `?school=…`
- [ ] Default state has no `school` param in URL (stays clean for UW)
- [ ] Reload with `?school=University%20of%20Pennsylvania` lands on UPenn events
- [ ] Combine with other filters (search, categories, dates) — confirm all filters compose